### PR TITLE
Removing Laravel name from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # \PHP
 ## Fix inconsistencies in the PHP language (naming, parameter order, passing by reference and more).
 
-PHP is great with Composer and PSR, but legacy stuff in the language itself makes it harder to use than it should be (see http://phpsadness.com/).
+PHP is great. Composer, PHP-FIG, and all the different frameworks make it even greater, but legacy stuff in the language itself makes it harder to use than it should be (see http://phpsadness.com/).
 
 Let's namespace PHP functions and bring some sanity.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # \PHP
 ## Fix inconsistencies in the PHP language (naming, parameter order, passing by reference and more).
 
-PHP is great with Composer, PSR and Laravel, but legacy stuff in the language itself makes it harder to use than it should be (see http://phpsadness.com/).
+PHP is great with Composer and PSR, but legacy stuff in the language itself makes it harder to use than it should be (see http://phpsadness.com/).
 
 Let's namespace PHP functions and bring some sanity.
 


### PR DESCRIPTION
The purpose of this PR is to remove Laravel name from README.md as it is not related to features library would provide. Please provide a PR cause most of the developers who develop enterprise application may be concerned using this library. I'm not going to start a framework war again but IMHO for the library, it would be better to apply this patch.