### PR TITLE
Add build script. Fixes #105, #106

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ tags
 
 # End of https://www.gitignore.io/api/vim,composer,osx
 .idea
+
+### Project ###
+
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,3 @@ tags
 
 # End of https://www.gitignore.io/api/vim,composer,osx
 .idea
-
-### Project ###
-
-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ install:
 script:
   - composer run-script phpunit
   - composer run-script phpcs
+  - composer run-script build

--- a/build.php
+++ b/build.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Returns the line number at which the first function declaration is found
+ * @param string $file Full path to the file we're working with
+ * @return mixed Line number or false
+ */
+function first_function_at($file)
+{
+    $src_code = file_get_contents($file);
+    $tokens = token_get_all($src_code, TOKEN_PARSE);
+
+    foreach ($tokens as $token) {
+        if (!is_array($token)) {
+            continue;
+        }
+
+        if ($token[0] == T_FUNCTION) {
+            return $token[2];
+        }
+    }
+
+    return false;
+}
+
+try {
+    // concatenate files
+    if (!is_writable(__DIR__)) {
+        throw new Exception('repo dir should be writable by build script');
+    }
+
+    if (!is_dir('dist/')) {
+        mkdir('dist/');
+    }
+
+    $concat_code = '';
+    $files = glob('src/*.php');
+
+    $concat_code .= "<?php\n";
+    $concat_code .= "declare(strict_types=1);\n";
+    $concat_code .= "namespace Zubr;\n\n";
+
+    foreach ($files as $file) {
+        $starting_line = first_function_at($file);
+        if ($starting_line === false) {
+            throw new Exception('unable to detect function');
+        }
+
+        $lines = file($file);
+        $offset = $starting_line - 1;
+
+        $concat_code .= implode('', array_slice($lines, $offset));
+    }
+
+    $concat_code .= "?>";
+
+    file_put_contents('dist/zubr.php', $concat_code, LOCK_EX);
+} catch (Exception $e) {
+    trigger_error($e->getMessage(), E_USER_ERROR);
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "autoload": {
         "files": [
-            "./src/functions.php"
+            "./dist/zubr.php"
         ]
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "scripts": {
         "phpunit": "./vendor/bin/phpunit",
-        "phpcs": "./vendor/bin/phpcs --standard=PSR2 src"
+        "phpcs": "./vendor/bin/phpcs --standard=PSR2 src",
+		"concat": "php ./build.php"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
     "scripts": {
         "phpunit": "./vendor/bin/phpunit",
         "phpcs": "./vendor/bin/phpcs --standard=PSR2 src",
-		"concat": "php ./build.php"
+		"build": "php ./build.php"
     }
 }

--- a/dist/zubr.php
+++ b/dist/zubr.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+namespace Zubr;
+
+function array_change_key_case(array $input, $case = null)
+{
+    return \array_change_key_case($input, $case);
+}
+function array_chunk(array $input, int $size, bool $preserve_keys = false)
+{
+    return \array_chunk($input, $size, $preserve_keys);
+}
+function array_column(array $array, $column, $index_key = null): array
+{
+    return \array_column($array, $column, $index_key);
+}
+function class_exists(string $className, bool $autoload = true): bool
+{
+    return \class_exists($className, $autoload);
+}
+function html_entities(
+    string $string,
+    int $flags = ENT_COMPAT | ENT_HTML401,
+    string $encoding = null,
+    bool $doubleEncode = true
+): string {
+    $encoding = $encoding ?? ini_get('default_charset');
+    return \htmlentities($string, $flags, $encoding, $doubleEncode);
+}
+function in_array(array $haystack, $needle, bool $strict = false): bool
+{
+    return \in_array($needle, $haystack, $strict);
+}
+function parse_url(string $url, int $component = -1)
+{
+    return \parse_url($url, $component);
+}
+?>

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,9 +1,0 @@
-<?php
-
-require_once __DIR__.'/html_entities.php';
-require_once __DIR__.'/class_exists.php';
-require_once __DIR__.'/parse_url.php';
-require_once __DIR__.'/array_chunk.php';
-require_once __DIR__.'/in_array.php';
-require_once __DIR__.'/array_change_key_case.php';
-require_once __DIR__.'/array_column.php';


### PR DESCRIPTION
I've implemented a primitive build script. At the moment it just concatenates our functions, but we can make it do more stuff in the future as needed.

Since we're concatenating, I removed the `functions.php` file. It's of course no longer necessary to manually add functions there.

To run the script:

```shell
composer run-script build
```

You should see a new file dist/zubr.php with all functions. ~~If everything works, we can enable building automatically via Travis~~ I have also enabled building automatically via Travis, must check if everything works smoothly.

NOTE: I'm assuming PHP is `php` (not sure if we should support other configurations, I'm open to suggestions).